### PR TITLE
Fix getRunEnergy() returning a value multiplied by 100

### DIFF
--- a/TScripts/src/main/java/net/runelite/client/plugins/tscripts/api/definitions/GLocalPlayer.java
+++ b/TScripts/src/main/java/net/runelite/client/plugins/tscripts/api/definitions/GLocalPlayer.java
@@ -56,7 +56,7 @@ public class GLocalPlayer implements GroupDefinition
         );
         addMethod(methods, "getRunEnergy", Type.INT,
                 ImmutableMap.of(),
-                function -> Static.getClient().getEnergy(),
+                function -> Static.getClient().getEnergy() / 100,
                 "Returns the run energy of the local player"
         );
         addMethod(methods, "runEnabled", Type.INT,


### PR DESCRIPTION
the returned value is too fine

![image](https://github.com/Bia10/TScriptsRepository/assets/2548763/6518e0cf-dfc4-4d67-a4bd-17dbda30555e)

as we can see 133 is actually 1.33% run energy